### PR TITLE
Fix installing the package from pip.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 setup(
@@ -7,4 +7,5 @@ setup(
     author='Andrew Plummer',
     author_email='plummer574@gmail.com',
     url='https://github.com/plumdog/django_migration_testcase',
+    packages=find_packages(),
     install_requires=['Django>=1.4'])


### PR DESCRIPTION
After installing from pip, without this change I get:

```
>>> from django_migration_testcase import MigrationTest
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named django_migration_testcase
```

After this change I can import it. Haven't fully tested it with Django yet!