### PR TITLE
Ensure that get_model_after is called after running the migration.

### DIFF
--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -17,7 +17,7 @@ class ExampleMigrationTest(MigrationTest):
 
         self.run_migration()
 
-        MyModel = self.get_model_before('MyModel')
+        MyModel = self.get_model_after('MyModel')
         self.assertEqual(MyModel.objects.count(), 10)
 
     def test_invalid_field(self):
@@ -81,8 +81,6 @@ class PopulateDoubleNumberTest(MigrationTest):
     def test_migration(self):
         MyModel = self.get_model_before('MyModel')
 
-        MyModel = self.get_model_before('MyModel')
-
         for i in range(10):
             mymodel = MyModel()
             mymodel.name = 'example name {}'.format(i)
@@ -107,5 +105,5 @@ class GetModelMigrationTest(MigrationTest):
 
         self.run_migration()
 
-        MyModel = self.get_model_before('test_app.MyModel')
+        MyModel = self.get_model_after('test_app.MyModel')
         self.assertEqual(MyModel.__name__, 'MyModel')


### PR DESCRIPTION
(Also removes a duplicated line.)

I'm not 100% sure about these changes, but I think they're copy & paste errors. I think you wanted to use `get_model_after` instead of `get_model_before` in a couple of places.

If not, could you explain why `get_model_before` was used in those places? (And I'll revert these changes and try to add some comments. :smile: )