### PR TITLE
Fix get model for django migrations

### DIFF
--- a/django_migration_testcase/django_migrations.py
+++ b/django_migration_testcase/django_migrations.py
@@ -10,6 +10,9 @@ class MigrationTest(TransactionTestCase):
     __abstract__ = True
 
     def setUp(self):
+        self.apps_before = None
+        self.apps_after = None
+
         super(MigrationTest, self).setUp()
         call_command('migrate', self.app_name, self.before,
                      no_initial_data=True, verbosity=0)
@@ -36,13 +39,15 @@ class MigrationTest(TransactionTestCase):
 
     def get_model_before(self, model_name):
         app_name, model_name = self._get_app_and_model_name(model_name)
-        return (self._get_apps_for_migration(app_name, self.before)
-                .get_model(app_name, model_name))
+        if not self.apps_before:
+            self.apps_before = self._get_apps_for_migration(app_name, self.before)
+        return self.apps_before.get_model(app_name, model_name)
 
     def get_model_after(self, model_name):
         app_name, model_name = self._get_app_and_model_name(model_name)
-        return (self._get_apps_for_migration(app_name, self.after)
-                .get_model(app_name, model_name))
+        if not self.apps_after:
+            self.apps_after = self._get_apps_for_migration(app_name, self.after)
+        return self.apps_after.get_model(app_name, model_name)
 
     def run_migration(self):
         call_command('migrate', self.app_name, self.after,

--- a/tests/test_app/migrations/0005_foreignmodel.py
+++ b/tests/test_app/migrations/0005_foreignmodel.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('test_app', '0004_populate_mymodel_double_number'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ForeignModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=100)),
+                ('my', models.ForeignKey(to='test_app.MyModel')),
+            ],
+        ),
+    ]

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -5,3 +5,8 @@ class MyModel(models.Model):
     name = models.CharField(max_length=100)
     number = models.IntegerField(null=True)
     double_number = models.IntegerField(null=True)
+
+
+class ForeignModel(models.Model):
+    name = models.CharField(max_length=100)
+    my = models.ForeignKey(MyModel)

--- a/tests/test_app/south_migrations/0005_auto__add_foreignmodel.py
+++ b/tests/test_app/south_migrations/0005_auto__add_foreignmodel.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'ForeignModel'
+        db.create_table(u'test_app_foreignmodel', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('my', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['test_app.MyModel'])),
+        ))
+        db.send_create_signal(u'test_app', ['ForeignModel'])
+
+    def backwards(self, orm):
+        # Deleting model 'ForeignModel'
+        db.delete_table(u'test_app_foreignmodel')
+
+    models = {
+        u'test_app.foreignmodel': {
+            'Meta': {'object_name': 'ForeignModel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'my': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['test_app.MyModel']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'test_app.mymodel': {
+            'Meta': {'object_name': 'MyModel'},
+            'double_number': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'number': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        }
+    }
+
+    complete_apps = ['test_app']

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -129,7 +129,7 @@ class ForeignKeyTest(MigrationTest):
         my = MyModel(name='test_my', number=1, double_number=3.14)
         my.save()
 
-        foreign = ForeignModel(name='test_foreign', my=my)
+        ForeignModel(name='test_foreign', my=my)
 
     def test_migration2(self):
         """Same test as test_migration, but this one passes."""
@@ -149,7 +149,7 @@ class ForeignKeyTest(MigrationTest):
         my = MyModel(name='test_my', number=1, double_number=3.14)
         my.save()
 
-        foreign = ForeignModel(name='test_foreign', my=my)
+        ForeignModel(name='test_foreign', my=my)
 
     def test_migration_clearly(self):
         """A clear illustration of the problem."""


### PR DESCRIPTION
To close #12

In django>=1.7, each time we create the apps for a migration state and get a model class, the instances don't match - this breaks when trying to assign a model instance to a foreign key relation. The solution is to cache the apps.

Previously
`self.get_model_after('MyModel') != self.get_model_after('MyModel')`
Now
`self.get_model_after('MyModel') is self.get_model_after('MyModel')`