### PR TITLE
Raise exception if wrong get_model called

### DIFF
--- a/django_migration_testcase/base.py
+++ b/django_migration_testcase/base.py
@@ -2,6 +2,10 @@ from django.test import TransactionTestCase
 from django.core.management import call_command
 
 
+class InvalidModelStateError(Exception):
+    pass
+
+
 class BaseMigrationTestCase(TransactionTestCase):
     __abstract__ = True
 
@@ -26,6 +30,17 @@ class BaseMigrationTestCase(TransactionTestCase):
             call_command('migrate', app_name,
                          verbosity=0, no_initial_data=True)
         super(BaseMigrationTestCase, self).tearDown()
+
+    def setUp(self):
+        self._migration_run = False
+
+    def _check_migration_run(self):
+        if not self._migration_run:
+            raise InvalidModelStateError('Migration(s) not yet run, invalid state requested')
+
+    def _check_migration_not_run(self):
+        if self._migration_run:
+            raise InvalidModelStateError('Migration(s) already run, invalid state requested')
 
     def get_model_before(self, model_name):
         raise NotImplementedError()

--- a/django_migration_testcase/django_migrations.py
+++ b/django_migration_testcase/django_migrations.py
@@ -37,9 +37,12 @@ class MigrationTest(BaseMigrationTestCase):
         for app_name, version in self.after:
             call_command('migrate', app_name, version,
                          verbosity=0, no_initial_data=True)
+        self._migration_run = True
 
     def get_model_before(self, model_name):
+        self._check_migration_not_run()
         return self._get_model(model_name, self.before, self.apps_before)
 
     def get_model_after(self, model_name):
+        self._check_migration_run()
         return self._get_model(model_name, self.after, self.apps_after)

--- a/django_migration_testcase/south_migrations.py
+++ b/django_migration_testcase/south_migrations.py
@@ -52,15 +52,18 @@ class MigrationTest(BaseMigrationTestCase):
         return orm[model_name]
 
     def get_model_before(self, model_name):
+        self._check_migration_not_run()
         return self._get_model(model_name, self.before_orm)
 
     def get_model_after(self, model_name):
+        self._check_migration_run()
         return self._get_model(model_name, self.after_orm)
 
     def run_migration(self):
         for app_name, version in self.after_migrations:
             call_command('migrate', app_name, version,
                          verbosity=0, no_initial_data=True)
+        self._migration_run = True
 
     def _get_migration_number(self, migration_name):
         # TODO: make this better and report exception

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -1,4 +1,5 @@
 from django_migration_testcase import MigrationTest
+from django_migration_testcase.base import InvalidModelStateError
 
 
 class ExampleMigrationTest(MigrationTest):
@@ -163,3 +164,18 @@ class ForeignKeyTest(MigrationTest):
         MyModel2 = self.get_model_after('test_app.MyModel')
 
         self.assertEqual(MyModel, MyModel2)
+
+
+class UtilsMigrationTest(MigrationTest):
+    before = '0001_initial'
+    after = '0002_mymodel_number'
+    app_name = 'test_app'
+
+    def test_migration_not_run_exception(self):
+        with self.assertRaises(InvalidModelStateError):
+            self.get_model_after('MyModel')
+
+    def test_migration_already_run_exception(self):
+        self.run_migration()
+        with self.assertRaises(InvalidModelStateError):
+            self.get_model_before('MyModel')

--- a/tests/test_second_app/tests.py
+++ b/tests/test_second_app/tests.py
@@ -17,7 +17,7 @@ class SecondAppMigrationTest(MigrationTest):
 
         self.run_migration()
 
-        MyModel = self.get_model_before('MyModel')
+        MyModel = self.get_model_after('MyModel')
         self.assertEqual(MyModel.objects.count(), 10)
 
 


### PR DESCRIPTION
Also fixes a misuse in the tests that this found.

To close #14 