### PR TITLE
Add migration method for overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ see
 I've tried to unravel the migrations framework to do the same thing
 here, so that we load models dynamically.
 
+The `migrate` and `migrate_kwargs` methods
+------------------------------------------
+
+The test method has a `migrate` method that takes an app name, a
+version and an optional `fake` boolean. By default, this just calls:
+```python
+call_command('migrate', app_name, version,
+             fake=fake, verbosity=0, no_initial_data=True)
+```
+
+If you need to alter your migrate command, you can either override
+this method, or you might just override `migrate_kwargs`, which by
+default sets `verbosity=0` and `no_initial_data=True`. Extend this to
+pass more options/different options. Note that if you try to set a
+`fake` kwarg from this method, it will be ignored.
+
 Tests
 -----
 

--- a/django_migration_testcase/base.py
+++ b/django_migration_testcase/base.py
@@ -27,8 +27,7 @@ class BaseMigrationTestCase(TransactionTestCase):
         # state so that we don't get errors when the final truncating
         # happens.
         for app_name, _ in self.after:
-            call_command('migrate', app_name,
-                         verbosity=0, no_initial_data=True)
+            self.migrate(app_name, version=None)
         super(BaseMigrationTestCase, self).tearDown()
 
     def setUp(self):
@@ -50,6 +49,20 @@ class BaseMigrationTestCase(TransactionTestCase):
 
     def run_migration(self):
         raise NotImplementedError()
+
+    def migrate_kwargs(self):
+        return {'verbosity': 0,
+                'no_initial_data': True}
+
+    def migrate(self, app_name, version, fake=False):
+        kwargs = self.migrate_kwargs()
+        kwargs['fake'] = fake
+        # For Django 1.7 - does a len() check on args.
+        if version:
+            args = ('migrate', app_name, version)
+        else:
+            args = ('migrate', app_name)
+        call_command(*args, **kwargs)
 
     def _get_app_and_model_name(self, model_name):
         if '.' in model_name:

--- a/django_migration_testcase/django_migrations.py
+++ b/django_migration_testcase/django_migrations.py
@@ -1,5 +1,4 @@
 import django
-from django.core.management import call_command
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
 
@@ -14,8 +13,7 @@ class MigrationTest(BaseMigrationTestCase):
 
         super(MigrationTest, self).setUp()
         for app_name, version in self.before:
-            call_command('migrate', app_name, version,
-                         no_initial_data=True, verbosity=0)
+            self.migrate(app_name, version)
 
     def _get_apps_for_migration(self, migration_states):
         loader = MigrationLoader(connection)
@@ -41,8 +39,7 @@ class MigrationTest(BaseMigrationTestCase):
 
     def run_migration(self):
         for app_name, version in self.after:
-            call_command('migrate', app_name, version,
-                         verbosity=0, no_initial_data=True)
+            self.migrate(app_name, version)
         self._migration_run = True
 
     def get_model_before(self, model_name):

--- a/django_migration_testcase/south_migrations.py
+++ b/django_migration_testcase/south_migrations.py
@@ -1,5 +1,3 @@
-from django.core.management import call_command
-
 from south.migration import Migrations
 
 from .base import BaseMigrationTestCase
@@ -36,10 +34,8 @@ class MigrationTest(BaseMigrationTestCase):
 
         for app_name, version in self.before_migrations:
             # Do a fake migration first to update the migration history.
-            call_command('migrate', app_name,
-                         fake=True, verbosity=0, no_initial_data=True)
-            call_command('migrate', app_name, version,
-                         verbosity=0, no_initial_data=True)
+            self.migrate(app_name, version=None, fake=True)
+            self.migrate(app_name, version=version)
 
     def _get_model(self, model_name, orm_dict):
         app_name, model_name = self._get_app_and_model_name(model_name)
@@ -61,8 +57,7 @@ class MigrationTest(BaseMigrationTestCase):
 
     def run_migration(self):
         for app_name, version in self.after_migrations:
-            call_command('migrate', app_name, version,
-                         verbosity=0, no_initial_data=True)
+            self.migrate(app_name, version)
         self._migration_run = True
 
     def _get_migration_number(self, migration_name):


### PR DESCRIPTION
Adds `migrate` and `migrate_kwargs` methods to customise the `migrate` command that is run.