### PR TITLE
Extends tox.ini scope

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # All "modern" pythons for django 1.6 and above, but only python2 for
 # 1.4 and 1.5 (1.5 introduced experimental python3 support, but is no
 # longer a supported Django version.
-envlist = py{27,33,34}-django1{6,7,8},py27-django1{4,5}
+envlist = py{34,35}-django1{9,10},py{27,33,34}-django1{6,7,8},py27-django1{4,5}
 
 [testenv]
 passenv = USER
@@ -16,6 +16,8 @@ deps =
     django1{4,5,6}: south
     django17: Django==1.7
     django18: Django==1.8
+    django19: Django==1.9
+    django110: Django==1.10
 
     psycopg2
 


### PR DESCRIPTION
I would like to use this application with Django 1.10 but it misses some kind of `noinput` parameter and interactively asks about removing stale state of my application. Any help appreciated on this work in progress (porting django_migration_testcase to Django 1.10) :)