### PR TITLE
Add Python Version trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,14 @@ setup(
     description='For testing migrations in Django',
     url='https://github.com/plumdog/django_migration_testcase',
     packages=find_packages(),
-    install_requires=['Django>=1.4'])
+    install_requires=['Django>=1.4'],
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ]
+)


### PR DESCRIPTION
I used [caniusepython3](https://pypi.org/project/caniusepython3/), which among other things checks the Pypi trove classifiers to determine if a requirement is Python 3 compatible. To my surprise it flagged `django-migration-testcase` as only compatible with Python 2 which I know to be incorrect given CI runs with 3.7.